### PR TITLE
Fix reference to Heroku::Builder::BuildError

### DIFF
--- a/lib/anvil/heroku/manifest.rb
+++ b/lib/anvil/heroku/manifest.rb
@@ -53,7 +53,7 @@ class Heroku::Manifest
         end
       rescue EOFError
         puts
-        raise BuildError, "terminated unexpectedly"
+        raise Heroku::Builder::BuildError, "terminated unexpectedly"
       end
 
       code = if res["x-exit-code"].nil?


### PR DESCRIPTION
BuildError is not in scope inside Heroku::Manifest - this patch specifies the fully qualified name.
