### PR TITLE
fixes uninitialized constant Heroku::Manifest::BuildError (NameError)

### DIFF
--- a/lib/anvil/heroku/manifest.rb
+++ b/lib/anvil/heroku/manifest.rb
@@ -53,7 +53,7 @@ class Heroku::Manifest
         end
       rescue EOFError
         puts
-        raise BuildError, "terminated unexpectedly"
+        raise Heroku::Builder::BuildError, "terminated unexpectedly"
       end
 
       code = if res["x-exit-code"].nil?


### PR DESCRIPTION
ran into an issue with anvil and ran into this exception while printing out an error.

```
    Error:       uninitialized constant Heroku::Manifest::BuildError (NameError)
    Backtrace:   /home/hone/.heroku/plugins/heroku-anvil/lib/anvil/heroku/manifest.rb:56:in `rescue in block in build'
                 /home/hone/.heroku/plugins/heroku-anvil/lib/anvil/heroku/manifest.rb:50:in `block in build'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1322:in `block (2 levels) in transport_request'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:2671:in `reading_body'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1321:in `block in transport_request'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1316:in `catch'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1316:in `transport_request'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1293:in `request'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1286:in `block in request'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:745:in `start'
                 /home/hone/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/net/http.rb:1284:in `request'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
                 /home/hone/.heroku/plugins/heroku-anvil/lib/anvil/heroku/manifest.rb:46:in `build'
                 /home/hone/.heroku/plugins/heroku-anvil/lib/anvil/heroku/command/build.rb:55:in `index'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/gems/heroku-2.30.0/lib/heroku/command.rb:179:in `run'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/gems/heroku-2.30.0/lib/heroku/cli.rb:25:in `start'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/gems/heroku-2.30.0/bin/heroku:16:in `<top (required)>'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/bin/heroku:23:in `load'
                 /home/hone/.rvm/gems/ruby-1.9.3-p194@heroku_work/bin/heroku:23:in `<main>'
```
