### PR TITLE
rename --release [APP] to --release APP

### DIFF
--- a/lib/anvil/heroku/command/build.rb
+++ b/lib/anvil/heroku/command/build.rb
@@ -24,7 +24,7 @@ class Heroku::Command::Build < Heroku::Command::Base
   #
   # -b, --buildpack URL  # use a custom buildpack
   # -p, --pipeline       # pipe compile output to stderr and only put the slug url on stdout
-  # -r, --release [APP]  # release the slug to an app (defaults to current app detected from git)
+  # -r, --release APP    # release the slug to an app (defaults to current app detected from git)
   # -t, --type TYPE      # build a slug of the given type (tgz, deb)
   #
   def index


### PR DESCRIPTION
`--release [APP]` results in options[:release] being boolean instead of the app name.
